### PR TITLE
Update the port to be 9483

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ MAINTAINER  The Presto_exporter Authors <presto-pj@mail.yahoo.co.jp>
 
 COPY presto_exporter /bin/presto_exporter
 
-EXPOSE     9482
+EXPOSE     9483
 ENTRYPOINT ["/bin/presto_exporter"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This image is configurable using different flags
 
 | Flag name          | Default    | Description                                          |
 | ------------------ | ---------- | ---------------------------------------------------- |
-| web.listen-address | :9482      | Address to listen on for web interface and telemetry |
+| web.listen-address | :9483      | Address to listen on for web interface and telemetry |
 | web.telemetry-path | /metrics   | Path under which to expose metrics                   |
 
 Help on flags:

--- a/presto_exporter.go
+++ b/presto_exporter.go
@@ -91,7 +91,7 @@ func (e Exporter) Describe(ch chan<- *prometheus.Desc) {
 
 func main() {
 	var (
-		listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9482").String()
+		listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9483").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		opts          = Exporter{}
 	)


### PR DESCRIPTION
この間で9482ポートは利用されてしまいました
順番の9483に設定し直す

ポート参照
https://github.com/prometheus/prometheus/wiki/Default-port-allocations